### PR TITLE
Export import config

### DIFF
--- a/js/export_config.js
+++ b/js/export_config.js
@@ -1,0 +1,12 @@
+import { guiParams } from './setup_gui.js';
+
+export function exportParamsToFile() {
+  const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(guiParams, null, 2));
+  const downloadAnchorNode = document.createElement('a');
+  const fileName = `Vizaj_Configuration_${new Date().toISOString().slice(0,19).replace(/:/g,"-")}.json`;
+  downloadAnchorNode.setAttribute("href", dataStr);
+  downloadAnchorNode.setAttribute("download", fileName);
+  document.body.appendChild(downloadAnchorNode);
+  downloadAnchorNode.click();
+  downloadAnchorNode.remove();
+}

--- a/js/import_config.js
+++ b/js/import_config.js
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import { updateBackgroundColor } from "./add_light_and_background.js";
-import { updateBrainMeshVisibility, updateExtraItemMaterial } from "./draw_cortex.js";
+import {updateBrainMeshVisibility, updateExtraItemMaterial, updateExtraItemMesh} from "./draw_cortex.js";
 import { redrawDegreeLines, updateAllDegreeLineLength, updateAllDegreeLineVisibility } from "./draw_degree_line.js";
 import { updateAllSensorMaterial, updateAllSensorRadius } from "./draw_sensors.js";
 import { redrawLinks, updateAllLinkMaterial, updateLinkOutline, updateVisibleLinks } from "./link_builder/draw_links";
@@ -75,6 +75,7 @@ const updateSettingsFromConfig = () => {
   updateBackgroundColor();
   updateBrainMeshVisibility();
   updateExtraItemMaterial();
+  updateExtraItemMesh()
   updateVisibleLinks();
   updateAllLinkMaterial();
   updateLinkOutline();

--- a/js/import_config.js
+++ b/js/import_config.js
@@ -1,0 +1,89 @@
+import * as THREE from "three";
+import { updateBackgroundColor } from "./add_light_and_background.js";
+import { updateBrainMeshVisibility, updateExtraItemMaterial } from "./draw_cortex.js";
+import { redrawDegreeLines, updateAllDegreeLineLength, updateAllDegreeLineVisibility } from "./draw_degree_line.js";
+import { updateAllSensorMaterial, updateAllSensorRadius } from "./draw_sensors.js";
+import { redrawLinks, updateAllLinkMaterial, updateLinkOutline, updateVisibleLinks } from "./link_builder/draw_links";
+import { guiParams } from './setup_gui.js';
+import { camera, gui, linkMeshList, controls, scene } from '../public/main.js';
+
+/**
+ * Handles file input change event and imports parameters from selected file.
+ * @param {Event} event
+ */
+const handleConfigInputChange = (event) => {
+  const file = event.target.files[0];
+  if (!file) {
+    alert('No file selected.');
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    try {
+      const json = JSON.parse(e.target.result);
+      Object.assign(guiParams, json);
+      updateGuiControls();
+      updateVisualSettings();
+      updateSettingsFromConfig();
+    } catch (error) {
+      alert('Invalid JSON format. Please select a valid configuration file.');
+      console.error('JSON parse error:', error);
+    }
+  };
+  reader.readAsText(file);
+};
+
+/**
+ * Updates all GUI controls to reflect the current parameters.
+ */
+const updateGuiControls = () => {
+  gui.__controllers.forEach(controller => controller.updateDisplay());
+  Object.values(gui.__folders).forEach(folder => {
+    folder.__controllers.forEach(controller => controller.updateDisplay());
+  });
+};
+
+/**
+ * Updates visual settings based on current parameters.
+ */
+const updateVisualSettings = () => {
+  camera.autoRotate = guiParams.autoRotateCamera;
+  camera.autoRotateSpeed = guiParams.autoRotateSpeed;
+  scene.background = new THREE.Color(guiParams.backgroundColor);
+  updateLinkVisibility(guiParams.linkDensity);
+};
+
+/**
+ * Updates link visibility based on density parameter.
+ * @param {number} density
+ */
+const updateLinkVisibility = (density) => {
+  linkMeshList.forEach(link => {
+    link.visible = Math.random() < density;
+  });
+};
+
+/**
+ * Updates all settings and redraws visuals from config.
+ */
+const updateSettingsFromConfig = () => {
+  controls.autoRotate = guiParams.autoRotateCamera;
+  controls.autoRotateSpeed = guiParams.autoRotateSpeed;
+  controls.update();
+
+  updateBackgroundColor();
+  updateBrainMeshVisibility();
+  updateExtraItemMaterial();
+  updateVisibleLinks();
+  updateAllLinkMaterial();
+  updateLinkOutline();
+  updateAllSensorRadius();
+  updateAllSensorMaterial();
+  updateAllDegreeLineVisibility();
+  updateAllDegreeLineLength();
+  redrawLinks();
+  redrawDegreeLines();
+};
+
+export { handleConfigInputChange };

--- a/js/setup_gui.js
+++ b/js/setup_gui.js
@@ -3,7 +3,9 @@ import { gui, controls,
     csvConnMatrixInput,
     csvNodePositionsInput,
     csvNodeLabelsInput,
-    jsonInput } from '../public/main';
+    jsonInput,
+    configInput
+} from '../public/main';
 import { updateAllSensorRadius,
     updateAllSensorMaterial } from './draw_sensors';
 import { redrawLinks, updateLinkOutline, updateVisibleLinks, updateAllLinkMaterial, ecoFiltering } from './link_builder/draw_links';
@@ -22,12 +24,14 @@ import { export2DImage, export3Dgltf, isExporting2DImage } from './export_image'
 import { updateBackgroundColor, resetBackgroundColor } from './add_light_and_background';
 import { ColorMapCanvas } from './link_builder/color_map_sprite';
 import { showLogs, hideLogs } from "../js/logs_helper";
+import { exportParamsToFile } from './export_config';
 
 const guiParams = {
     loadConnectivityMatrixCsvFile: () => csvConnMatrixInput.click(),
     loadMontageCsvFile: () => {csvNodePositionsInput.click();},
     loadMontageLabelsCsvFile: () => {csvNodeLabelsInput.click();},
     loadJson: () => {jsonInput.click()},
+    loadConfig: () => {configInput.click()},
 
     autoRotateCamera: false,
     autoRotateSpeed: 2.0,
@@ -337,6 +341,11 @@ function setupGui() {
     const logsFolder = gui.addFolder('Logs');
     logsFolder.add(guiParams, 'showLogs').name("Show");
     logsFolder.add(guiParams, 'hideLogs').name("Hide");
+
+    const configFolder = gui.addFolder('Configuration');
+    configFolder.add({ exportParamsToFile }, 'exportParamsToFile').name('Export Conf');
+    configFolder.add(guiParams, 'loadConfig').name('Import');
+
 }
 
 export {

--- a/js/setup_gui.js
+++ b/js/setup_gui.js
@@ -343,7 +343,7 @@ function setupGui() {
     logsFolder.add(guiParams, 'hideLogs').name("Hide");
 
     const configFolder = gui.addFolder('Configuration');
-    configFolder.add({ exportParamsToFile }, 'exportParamsToFile').name('Export Conf');
+    configFolder.add({ exportParamsToFile }, 'exportParamsToFile').name('Export');
     configFolder.add(guiParams, 'loadConfig').name('Import');
 
 }

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
   <input type="file" id='csvNodePositions' class='fileInput' accept='.csv' />
   <input type="file" id='csvNodeLabels' class='fileInput' accept='.csv' />
   <input type="file" id='jsonInput' class='fileInput' accept='application/JSON'>
+  <input type="file" id='configInput' class='fileInput' accept='application/JSON'>
   <div id="colorMap">
     <div id="colorMapTopValue"></div>
     <canvas id="colorBar"></div>

--- a/public/main.js
+++ b/public/main.js
@@ -21,6 +21,7 @@ import { loadJsonData, jsonLoadingNodeCheckForError, jsonLoadingEdgeCheckForErro
 import { userLogError, userLogMessage } from "../js/logs_helper";
 import { GUI } from 'dat.gui';
 import { hexToHsl } from "../js/color_helper";
+import { handleConfigInputChange } from "../js/import_config.js";
 
 const highlightedLinksPreviousMaterials = [];
 
@@ -66,6 +67,7 @@ const csvConnMatrixInput = document.getElementById("csvConnMatrixInput");
 const csvNodePositionsInput = document.getElementById("csvNodePositions");
 const csvNodeLabelsInput = document.getElementById("csvNodeLabels");
 const jsonInput = document.getElementById("jsonInput");
+const configInput = document.getElementById("configInput");
 
 //intersectedNodeList is used to check wether the mouse intersects with a sensor
 var intersectedNode;
@@ -98,6 +100,7 @@ function init() {
   csvNodePositionsInput.addEventListener("change", handleMontageCoordinatesFileSelect, false);
   csvNodeLabelsInput.addEventListener("change", handleMontageLabelsFileSelect, false);
   jsonInput.addEventListener("change", handleJsonFileSelect, false);
+  configInput.addEventListener("change", handleConfigInputChange, false);
 }
 
 function animate() {
@@ -345,6 +348,7 @@ export {
     csvNodePositionsInput,
     csvNodeLabelsInput,
     jsonInput,
+    configInput,
     emptyIntersected,
     intersectedNode as intersectedNodeList,
     onWindowResize,


### PR DESCRIPTION
Added export and import actions of the configuration (object `guiParams`). 

The actions controls can be found in the control menu: 

<img width="2374" height="1880" alt="image" src="https://github.com/user-attachments/assets/425355cf-a0bc-468c-a694-eea3068d8d0c" />

The JS object `guiParams` is exported as json. Sample export: 
```json
{
  "autoRotateCamera": false,
  "autoRotateSpeed": 7.873561990253108,
  "linkDensity": 0.040100000000000004,
  "backgroundColor": "#33111b",
  "showExtraItem": true,
  "colorExtraItem": "#c0ffc7",
  "extraItemMeshShape": "cube",
  "showDegreeLines": false,
  "degreeLineRadius": 1,
  "degreeLineLength": 1,
  "degreeLineColor": "#9999ff",
  "degreeLineOpacity": 0.6,
  "linkHeight": 0.75,
  "linkTopPointHandleDistances": 0.5,
  "linkSensorAngles": 0.375,
  "linkSensorHandleDistances": 0.1,
  "linkTopPointAngle": 0,
  "linkThickness": 0,
  "linkOpacity": 1,
  "linkColorMap": "rainbow",
  "showColorMap": true,
  "sensorRadiusFactor": 1,
  "sensorOpacity": 0.29,
  "sensorColor": "#aaaaaa",
  "linkAlignmentTarget": 0,
  "linkGeometry": "Default",
  "splinePointsGeometry": 0
}
```

On import, all the previous settings are used to restore the `guiParams`, and all actions needed to change the view of the scene are triggered. 

**Note:** The support position, rotation, and scale, are not exported, as they're not part of the `guiParams` object (and can't be added easily). 