### PR TITLE
Rescale the colors of links after changing the number of links

### DIFF
--- a/js/setup_gui.js
+++ b/js/setup_gui.js
@@ -22,6 +22,7 @@ import { export2DImage, export3Dgltf, isExporting2DImage } from './export_image'
 import { updateBackgroundColor, resetBackgroundColor } from './add_light_and_background';
 import { ColorMapCanvas } from './link_builder/color_map_sprite';
 import { showLogs, hideLogs } from "../js/logs_helper";
+import { rescaleColors } from './link_builder/draw_links';
 
 const guiParams = {
     loadConnectivityMatrixCsvFile: () => csvConnMatrixInput.click(),
@@ -222,6 +223,7 @@ function setupGui() {
         .onChange (updateVisibleLinks)
         .step(.0001);
     linksToDisplayFolder.add(guiParams, 'ecoFiltering').name('ECO');
+    linksToDisplayFolder.add({ rescale: rescaleColors }, 'rescale').name('Rescale');
 
     const extraItemFolder = gui.addFolder('Support');
     extraItemFolder.add(guiParams, 'showExtraItem').onChange(updateBrainMeshVisibility).name('Show').listen();


### PR DESCRIPTION
This MR adds a "Rescale" button in the "Filtering" controls, which rescales the colors of the links, and the color bar, to min and max values of visible links.

#### Not scaled: 

<img width="2728" height="1880" alt="image" src="https://github.com/user-attachments/assets/047ce58c-f8dd-4bb0-9a50-f96c71e556d4" />

#### After rescale: 

<img width="2728" height="1880" alt="image" src="https://github.com/user-attachments/assets/bd3ab234-90db-4870-ba9c-b64782d2fd38" />

The colors of the link now extend to the full range of the chosen color palette. 

**Note 1**: The information that the colors are rescaled won't be exported with the rest of the configuration (see other MR). It is because, like for position of the support, the information that are not explicitely in the `guiParams` can not be easily exported. To do that, the app would need a complete refactoring to introduce the notion of "state" (`guiParams` stores a kind of state, but which not complete, as its primary purpose is only to manage the controls). 

**Note 2**: I put the button in the "Filtering" folder of the controls, but it could also be in "Links > Color Map". Let me know if you want that I change that.  

