### PR TITLE
Keep clicked nodes highlighted

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -5,7 +5,7 @@
   visibility: hidden;
 }
 
-#sensorName {
+.sensorName {
     position:fixed;
     z-index: 50;
     color: white;

--- a/js/highlight_sensors.js
+++ b/js/highlight_sensors.js
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { hexToHsl } from "../js/color_helper";
 
 /**
  * Create a DOM element to display the sensor label
@@ -100,11 +101,17 @@ function repositionLabelsOnCameraChange(sensors, camera, renderer) {
  * Highlight the links associated with a specific sensor node.
  * @param {*} sensorNode 
  * @param {*} links 
+ * @param {*} backgroundColor 3D scene background color in hex format
  */
-function highlightSensorLinks(sensorNode, links) {
+function highlightSensorLinks(sensorNode, links, backgroundColor) {
     const associatedLinks = links.filter((linkMesh) => linkMesh.link.node1 === sensorNode || linkMesh.link.node2 === sensorNode);
     for (const linkMesh of associatedLinks) {
-        linkMesh.mesh.material = new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 1, transparent: false });
+        let color = hexToHsl(backgroundColor).l < 50 ? new THREE.Color(1,1,1) : new THREE.Color(0,0,0);
+        linkMesh.mesh.material = new THREE.LineBasicMaterial({
+            color,
+            opacity: 1,
+            transparent: false
+        });
     }
 }
 

--- a/js/highlight_sensors.js
+++ b/js/highlight_sensors.js
@@ -74,13 +74,12 @@ function updateHoveredSensorLabel(intersectedNode, camera, renderer) {
 /**
  * Reposition sensor labels when the camera changes.
  * If a sensor does not have a label yet, create it.
- * @param {*} nodeStateMap 
+ * @param {*} sensors - map of sensor uuids with their corresponding 3D node
  * @param {*} camera 
  * @param {*} renderer 
  */
-function repositionLabelsOnCameraChange(nodeStateMap, camera, renderer) {
-  nodeStateMap.forEach((state, node) => {
-    if (state === 'highlighted') {
+function repositionLabelsOnCameraChange(sensors, camera, renderer) {
+  sensors.forEach((node, uuid) => {
     const vector = new THREE.Vector3();
     node.getWorldPosition(vector);
     vector.project(camera);
@@ -88,17 +87,30 @@ function repositionLabelsOnCameraChange(nodeStateMap, camera, renderer) {
     const x = (vector.x *  .5 + .5) * renderer.domElement.clientWidth;
     const y = (vector.y * -.5 + .5) * renderer.domElement.clientHeight;
 
-    let labelContainer = document.getElementById("sensorName-" + node.uuid);
+    let labelContainer = document.getElementById("sensorName-" + uuid);
     if (!labelContainer) {
-        labelContainer = createSensorLabel(node.uuid);
+        labelContainer = createSensorLabel(uuid);
     }
     moveSensorLabel(labelContainer, x, y);
     renameSensorLabel(labelContainer, node.name);
-  }});
+  });
+}
+
+/**
+ * Highlight the links associated with a specific sensor node.
+ * @param {*} sensorNode 
+ * @param {*} links 
+ */
+function highlightSensorLinks(sensorNode, links) {
+    const associatedLinks = links.filter((linkMesh) => linkMesh.link.node1 === sensorNode || linkMesh.link.node2 === sensorNode);
+    for (const linkMesh of associatedLinks) {
+        linkMesh.mesh.material = new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 1, transparent: false });
+    }
 }
 
 export { 
   removeSensorLabel, 
   repositionLabelsOnCameraChange, 
   updateHoveredSensorLabel,
+  highlightSensorLinks,
 };

--- a/js/highlight_sensors.js
+++ b/js/highlight_sensors.js
@@ -1,0 +1,104 @@
+import * as THREE from "three";
+
+/**
+ * Create a DOM element to display the sensor label
+ * @param {*} id - id of the sensor
+ */
+function createSensorLabel(id) {
+  const labelContainer = document.createElement("div");
+  labelContainer.id = "sensorName-" + id;
+  labelContainer.className = "sensorName";
+  const parentContainer = document.getElementById("sensorNameContainer");
+  parentContainer.appendChild(labelContainer);
+  document.body.appendChild(labelContainer);
+
+  return labelContainer;
+}
+
+/**
+ * Remove the sensor label from the DOM
+ * @param {*} uuid - uuid of the sensor
+ */
+function removeSensorLabel(uuid) {
+  const labelContainer = document.getElementById("sensorName-" + uuid);
+  if (labelContainer) {
+    labelContainer.parentNode.removeChild(labelContainer);
+  }
+}
+
+/**
+ * Move the sensor label to the specified position
+ * @param {*} container - label container DOM element
+ * @param {*} x - x position
+ * @param {*} y - y position
+ */
+function moveSensorLabel(container, x, y) {
+  container.style.top = y + "px";
+  container.style.left = x + "px";
+  container.style.visibility = 'visible';
+}
+
+/**
+ * Update the sensor label text
+ * @param {*} container - label container DOM element
+ * @param {*} label - new label text
+ */
+function renameSensorLabel(container, label) {
+  container.innerHTML = label;
+}
+
+/**
+ * Display label of the hovered sensor.
+ * If no node is being hovered, no label is shown.
+ * @param {*} intersectedNode - the node being hovered
+ * @param {*} camera
+ * @param {*} renderer 
+ */
+function updateHoveredSensorLabel(intersectedNode, camera, renderer) {
+  const hoveredSensorNameDiv = document.getElementById("hoveredSensorName");
+  if (intersectedNode) {
+    const vector = new THREE.Vector3();
+    intersectedNode.getWorldPosition(vector);
+    vector.project(camera);
+
+    const x = (vector.x *  .5 + .5) * renderer.domElement.clientWidth;
+    const y = (vector.y * -.5 + .5) * renderer.domElement.clientHeight;
+
+    moveSensorLabel(hoveredSensorNameDiv, x, y);
+    renameSensorLabel(hoveredSensorNameDiv, intersectedNode.name);
+  } else {
+    hoveredSensorNameDiv.style.visibility = 'hidden';
+  }
+}
+
+/**
+ * Reposition sensor labels when the camera changes.
+ * If a sensor does not have a label yet, create it.
+ * @param {*} nodeStateMap 
+ * @param {*} camera 
+ * @param {*} renderer 
+ */
+function repositionLabelsOnCameraChange(nodeStateMap, camera, renderer) {
+  nodeStateMap.forEach((state, node) => {
+    if (state === 'highlighted') {
+    const vector = new THREE.Vector3();
+    node.getWorldPosition(vector);
+    vector.project(camera);
+
+    const x = (vector.x *  .5 + .5) * renderer.domElement.clientWidth;
+    const y = (vector.y * -.5 + .5) * renderer.domElement.clientHeight;
+
+    let labelContainer = document.getElementById("sensorName-" + node.uuid);
+    if (!labelContainer) {
+        labelContainer = createSensorLabel(node.uuid);
+    }
+    moveSensorLabel(labelContainer, x, y);
+    renameSensorLabel(labelContainer, node.name);
+  }});
+}
+
+export { 
+  removeSensorLabel, 
+  repositionLabelsOnCameraChange, 
+  updateHoveredSensorLabel,
+};

--- a/js/link_builder/draw_links.js
+++ b/js/link_builder/draw_links.js
@@ -206,4 +206,6 @@ function rescaleColors() {
     updateLinkOutline,
     updateVisibleLinks,
     updateAllLinkMaterial,
-    ecoFiltering}
+    updateLinkMaterial,
+    ecoFiltering
+ };

--- a/js/setup_gui.js
+++ b/js/setup_gui.js
@@ -6,6 +6,7 @@ import { gui, controls,
     jsonInput,
     configInput,
     clearSelectedNodes,
+    redrawSelectedSensorLinks,
 } from '../public/main';
 import { updateAllSensorRadius,
     updateAllSensorMaterial } from './draw_sensors';
@@ -281,7 +282,12 @@ function setupGui() {
 
 
     const colorMapFolder = linkFolder.addFolder('Color map');
-    colorMapFolder.add(guiParams, 'linkColorMap', ['rainbow', 'cooltowarm', 'blackbody', 'grayscale']).onChange(updateAllLinkMaterial).name('Color map');
+    colorMapFolder.add(guiParams, 'linkColorMap', ['rainbow', 'cooltowarm', 'blackbody', 'grayscale'])
+        .onChange(() => {
+            updateAllLinkMaterial();
+            redrawSelectedSensorLinks();
+        })
+        .name('Color map');
     colorMapFolder.add(guiParams, 'showColorMap').onChange(() => {ColorMapCanvas.show(guiParams.showColorMap)}).name('Show color bar');
 
     const linkAlignmentTargetFolder = linkFolder.addFolder('Link alignment target');

--- a/js/setup_gui.js
+++ b/js/setup_gui.js
@@ -4,7 +4,8 @@ import { gui, controls,
     csvNodePositionsInput,
     csvNodeLabelsInput,
     jsonInput,
-    configInput
+    configInput,
+    clearSelectedNodes,
 } from '../public/main';
 import { updateAllSensorRadius,
     updateAllSensorMaterial } from './draw_sensors';
@@ -134,8 +135,9 @@ const guiParams = {
     export3Dgltf: () => export3Dgltf(),
 
     showLogs: showLogs,
-    hideLogs: hideLogs
-    
+    hideLogs: hideLogs,
+    clearSelectedNodes: clearSelectedNodes,
+
   };
 
 const premadeLinkGeometriesList = ['Default', 'Bell', 'Triangle', 'Circle', 'Circle2', 'Rounded square', 'Peak', 'Straight'];
@@ -348,6 +350,8 @@ function setupGui() {
     configFolder.add({ exportParamsToFile }, 'exportParamsToFile').name('Export');
     configFolder.add(guiParams, 'loadConfig').name('Import');
 
+    const resetFolder = gui.addFolder('Node/links selection');
+    resetFolder.add(guiParams, 'clearSelectedNodes').name('Reset selection');
 }
 
 export {

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,9 @@
     <canvas id="colorBar"></div>
     <div id="colorMapBottomValue"></div>
   </div>
-  <div id="sensorName"></div>
+  <div id="sensorNameContainer">
+    <div id="hoveredSensorName" class="sensorName"></div>
+  </div>
   <script src="main.js"></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -210,6 +210,12 @@ function clearSelectedNodes() {
   updateAllLinkMaterial();
 }
 
+function redrawSelectedSensorLinks() {
+  selectedSensors.forEach((sensor) => {
+    highlightSensorLinks(sensor, linkMeshList, guiParams.backgroundColor);
+  });
+}
+
 function resetSensorLinkMaterials(sensor) {
   const associatedLinks = linkMeshList.filter((linkMesh) => linkMesh.link.node1 === sensor || linkMesh.link.node2 === sensor);
   associatedLinks.forEach(linkMesh => {
@@ -386,4 +392,5 @@ export {
     uiCamera,
     mouseButtonIsDown,
     clearSelectedNodes,
+    redrawSelectedSensorLinks,
 };

--- a/public/main.js
+++ b/public/main.js
@@ -24,6 +24,7 @@ import { hexToHsl } from "../js/color_helper";
 import { handleConfigInputChange } from "../js/import_config.js";
 
 const highlightedLinksPreviousMaterials = [];
+const nodeStateMap = new Map();
 
 let cortexMeshUrl = require('../data/cortex_model.glb');
 let innerSkullMeshUrl = require('../data/innskull.glb');
@@ -111,7 +112,9 @@ function animate() {
   renderer.render(scene, camera);
   renderer.clearDepth();
   renderer.render(uiScene, uiCamera);
+  updateLabelPosition(nodeStateMap);
 }
+animate();
 
 function onWindowResize() {
   camera.aspect = window.innerWidth / window.innerHeight;
@@ -137,43 +140,139 @@ function onDocumentMouseMove(event) {
   const padding = 15;
   sensorNameDiv.style.top = event.clientY + padding + "px";
   sensorNameDiv.style.left = event.clientX + padding + "px";
+  hoverDisplayUpdate();
+
 }
 
-function onRendererMouseDown(event){
-  mouseButtonIsDown=true;
+function updateLabelPosition(nodeStateMap) {
+  nodeStateMap.forEach((state, node) => {
+    if (state === 'highlighted') {
+    const vector = new THREE.Vector3();
+    node.getWorldPosition(vector);
+    vector.project(camera);
+
+    const x = (vector.x *  .5 + .5) * renderer.domElement.clientWidth;
+    const y = (vector.y * -.5 + .5) * renderer.domElement.clientHeight;
+
+    sensorNameDiv.style.top = `${y}px`;
+    sensorNameDiv.style.left = `${x}px`;
+    sensorNameDiv.innerHTML = node.name;
+    sensorNameDiv.style.visibility = 'visible';
+}});
+}
+
+function onRendererMouseDown(event) {
+  mouseButtonIsDown = true;
   mouseDownDate = Date.now();
 }
 
-function onRendererMouseUp(event){
+function onRendererMouseUp(event) {
   mouseButtonIsDown = false;
-  if (Date.now() - mouseDownDate < 500){
-    onDocumentMouseClick(event);
+  if (Date.now() - mouseDownDate < 500) {
+    // Effectuer la détection de clic seulement si un nœud est effectivement intersecté
+    raycaster.setFromCamera(mouse, camera);
+    const intersects = raycaster.intersectObjects(sensorMeshList.map(x => x.mesh));
+    if (intersects.length > 0) {
+      onDocumentMouseClick(event);
+    }
   }
   updateTransformControlHistory();
 }
 
-function onDocumentMouseClick(event){
 
-}
+function onDocumentMouseClick(event) {
+  raycaster.setFromCamera(mouse, camera);
+  const intersects = raycaster.intersectObjects(sensorMeshList.map(x => x.mesh));
 
-function hoverDisplayUpdate() {
-  const intersects = getRaycastedNodes();
-  emptyIntersected();
-  if (intersects.length) {
-    intersectedNode = intersects[0].object;
-    fillIntersected();
+  if (intersects.length > 0) {
+    const selectedNode = intersects[0].object;
+
+    if (nodeStateMap.get(selectedNode) === 'highlighted') {
+      // Si le nœud est déjà surligné, on le remet à normal
+      selectedNode.material = sensorMaterial;
+      nodeStateMap.set(selectedNode, 'normal');
+    } else {
+      // Sinon, on le surligne
+      selectedNode.material = enlightenedSensorMaterial;
+      nodeStateMap.set(selectedNode, 'highlighted');
+    }
+
+    // Mise à jour des liens
+    for (const linkMesh of linkMeshList) {
+      if (linkMesh.link.node1 === selectedNode || linkMesh.link.node2 === selectedNode) {
+        if (nodeStateMap.get(selectedNode) === 'highlighted') {
+          linkMesh.mesh.material = new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 1, transparent: false });
+        } else {
+          linkMesh.mesh.material = new THREE.LineBasicMaterial({ color: new THREE.Color(0xff0000), opacity: 1, transparent: false });
+        }
+      }
+    }
   }
 }
 
-function getRaycastedNodes(){
+
+function hoverDisplayUpdate() {
   raycaster.setFromCamera(mouse, camera);
-  return raycaster.intersectObjects(sensorMeshList.map(x=>x.mesh));
+  const intersects = raycaster.intersectObjects(sensorMeshList.map(x => x.mesh));
+
+  if (intersects.length === 0) {
+    if (intersectedNode && nodeStateMap.get(intersectedNode) !== 'highlighted') {
+      intersectedNode.material = sensorMaterial;
+      updateLinkColors(intersectedNode, 0xff0000);
+      nodeStateMap.delete(intersectedNode);
+      intersectedNode = null;
+    }
+  } else {
+    const hoveredNode = intersects[0].object;
+    if (!nodeStateMap.get(hoveredNode) || nodeStateMap.get(hoveredNode) === 'normal') {
+      if (intersectedNode && nodeStateMap.get(intersectedNode) !== 'highlighted') {
+        intersectedNode.material = sensorMaterial;
+        updateLinkColors(intersectedNode, 0xff0000);
+      }
+      intersectedNode = hoveredNode;
+      if (nodeStateMap.get(hoveredNode) !== 'highlighted') {
+        hoveredNode.material = enlightenedSensorMaterial;
+        updateLinkColors(hoveredNode, 0xffffff);
+        nodeStateMap.set(hoveredNode, 'hovered');
+      }
+    }
+  }
+}
+
+function clearSelectedNodes() {
+  nodeStateMap.forEach((state, node) => {
+    if (state === 'highlighted') {
+      node.material = sensorMaterial;
+      nodeStateMap.set(node, 'normal');
+    }
+    sensorNameDiv.innerHTML = "";
+    sensorNameDiv.style.visibility = 'invisible';
+  });
+  nodeStateMap.clear();
+  linkMeshList.forEach(linkMesh => {
+    linkMesh.mesh.material = new THREE.LineBasicMaterial({ color: 0xff0000, opacity: 1, transparent: false });
+  });
+}
+
+
+function updateLinkColors(node, color) {
+  linkMeshList.forEach(linkMesh => {
+    if (linkMesh.link.node1 === node || linkMesh.link.node2 === node) {
+      linkMesh.originalMaterial = linkMesh.mesh.material; // Sauvegarder la couleur originale
+      linkMesh.mesh.material = new THREE.LineBasicMaterial({ color: color, opacity: 1, transparent: false });
+    }
+  });
+}
+
+function getRaycastedNodes() {
+  raycaster.setFromCamera(mouse, camera);
+  return raycaster.intersectObjects(sensorMeshList.map(x => x.mesh));
 }
 
 function emptyIntersected() {
   if (intersectedNode) {
     intersectedNode.material = sensorMaterial;
-    if (guiParams.sensorOpacity == 0){
+    if (guiParams.sensorOpacity == 0) {
       intersectedNode.visible = true;
     }
   }
@@ -183,27 +282,27 @@ function emptyIntersected() {
   while (highlightedLinksPreviousMaterials.length > 0) {
     const elem = highlightedLinksPreviousMaterials.shift();
     for (const linkMesh of linkMeshList
-      .filter((linkMesh) => linkMesh.link.node1 === elem.node1 && linkMesh.link.node2 === elem.node2)){
+      .filter((linkMesh) => linkMesh.link.node1 === elem.node1 && linkMesh.link.node2 === elem.node2)) {
       linkMesh.mesh.material = elem.material;
     }
   }
 }
 
 function fillIntersected() {
-  intersectedNode.material = enlightenedSensorMaterial;
-  intersectedNode.visible = true;
-  sensorNameDiv.innerHTML = intersectedNode.name;
-  if (sensorNameDiv.innerHTML){sensorNameDiv.style.visibility = 'visible';}
-  for (const linkMesh of linkMeshList){
-    if (linkMesh.link.node1 === intersectedNode || linkMesh.link.node2 === intersectedNode)
-    {
+    intersectedNode.material = enlightenedSensorMaterial;
+    intersectedNode.visible = true;
+    sensorNameDiv.innerHTML = intersectedNode.name;
+  if (sensorNameDiv.innerHTML) { sensorNameDiv.style.visibility = 'visible'; }
+  for (const linkMesh of linkMeshList) {
+    if (linkMesh.link.node1 === intersectedNode || linkMesh.link.node2 === intersectedNode) {
       highlightedLinksPreviousMaterials.push({
         node1: linkMesh.link.node1,
         node2: linkMesh.link.node2,
-        material: linkMesh.mesh.material});
-      let color = hexToHsl(guiParams.backgroundColor).l < 50 ? new THREE.Color(1,1,1) : new THREE.Color(0,0,0);
+        material: linkMesh.mesh.material
+      });
+      let color = hexToHsl(guiParams.backgroundColor).l < 50 ? new THREE.Color(1, 1, 1) : new THREE.Color(0, 0, 0);
       linkMesh.mesh.material = new THREE.LineBasicMaterial({
-        color : color,
+        color: color,
         opacity: 1,
         transparent: false
       });
@@ -211,7 +310,9 @@ function fillIntersected() {
   }
 }
 
-function getNewFileUrl(evt){
+
+
+function getNewFileUrl(evt) {
   if (evt.target.files.length === 0) { return; }
   const file = evt.target.files[0];
   return window.URL.createObjectURL(file);
@@ -221,9 +322,9 @@ function handleConnectivityMatrixFileSelect(evt) {
   const fileUrl = getNewFileUrl(evt);
   const fileName = evt.target.files[0].name;
   loadAndDrawLinksFromUrl(fileUrl).then(
-      ()=>{ userLogMessage("Connectivity matrix file " + fileName + "succesfully loaded.", "green")},
-        (e) => userLogError(e, fileName)
-    );
+    () => { userLogMessage("Connectivity matrix file " + fileName + "succesfully loaded.", "green") },
+    (e) => userLogError(e, fileName)
+  );
 }
 
 function handleMontageCoordinatesFileSelect(evt) {
@@ -231,7 +332,7 @@ function handleMontageCoordinatesFileSelect(evt) {
   const fileName = evt.target.files[0].name;
   clearLoadAndDrawSensors(sensorCoordinatesUrl)
     .then(() => userLogMessage("Coordinates file " + fileName + " succesfully loaded.", "green"),
-      (e)=>userLogError(e, fileName)
+      (e) => userLogError(e, fileName)
     );
 }
 
@@ -240,32 +341,32 @@ function handleMontageLabelsFileSelect(evt) {
   const fileName = evt.target.files[0].name;
   loadAndAssignSensorLabels(sensorLabelsUrl)
     .then(() => userLogMessage("Labels file " + fileName + " succesfully loaded.", "green"),
-      (e)=>userLogError(e, fileName)
+      (e) => userLogError(e, fileName)
     );
 }
 
-async function handleJsonFileSelect(evt){
+async function handleJsonFileSelect(evt) {
   const jsonUrl = getNewFileUrl(evt);
   const fileName = evt.target.files[0].name;
-  try{
+  try {
     const jsonData = await loadJsonData(jsonUrl);
-    if (!jsonData.graph){
+    if (!jsonData.graph) {
       throw new TypeError("Graph attribute is missing.");
     }
-    if (!jsonData.graph.nodes){
+    if (!jsonData.graph.nodes) {
       throw new TypeError("No nodes folder.");
     }
-    if (!jsonData.graph.edges){
+    if (!jsonData.graph.edges) {
       throw new TypeError("No edges folder.");
     }
 
     const graph = jsonData.graph;
-    const coordinatesList  = [];
+    const coordinatesList = [];
     const labelList = [];
     const linkList = [];
     const sensorIdMap = new Map();
     let i = 0;
-    for (const [key, value] of Object.entries(graph.nodes)){
+    for (const [key, value] of Object.entries(graph.nodes)) {
       jsonLoadingNodeCheckForError(key, value, i, sensorIdMap);
       i++;
       coordinatesList.push([parseFloat(value.position.x), parseFloat(value.position.y), parseFloat(value.position.z)]);
@@ -275,8 +376,8 @@ async function handleJsonFileSelect(evt){
       sensorIdMap.set(value.id.toString(), labelList.length - 1);
     }
 
-    i=0;
-    for (const [key, value] of Object.entries(graph.edges)){
+    i = 0;
+    for (const [key, value] of Object.entries(graph.edges)) {
       jsonLoadingEdgeCheckForError(key, value, i, coordinatesList.length, sensorIdMap);
       i++;
     }
@@ -287,12 +388,12 @@ async function handleJsonFileSelect(evt){
     await drawSensorsAndUpdateGlobalValues(coordinatesList);
     assignSensorLabels(labelList);
 
-    for (const [key, value] of Object.entries(graph.edges)){
+    for (const [key, value] of Object.entries(graph.edges)) {
       if (value.strength != 0 && value.strength)
-      linkList.push(generateLinkData(
-        sensorIdMap.get(value.source.toString()),
-        sensorIdMap.get(value.target.toString()),
-        value.strength));
+        linkList.push(generateLinkData(
+          sensorIdMap.get(value.source.toString()),
+          sensorIdMap.get(value.target.toString()),
+          value.strength));
     }
 
     await drawLinksAndUpdateVisibility(linkList);
@@ -300,7 +401,7 @@ async function handleJsonFileSelect(evt){
 
     userLogMessage('Json file ' + fileName + ' succesfully loaded.', 'green');
   }
-  catch(e){
+  catch (e) {
     userLogError(e, fileName);
 
   }
@@ -329,6 +430,9 @@ function connectToWebSocket() {
   });
 }
 
+
+
+
 export {
     scene,
     camera,
@@ -354,5 +458,6 @@ export {
     onWindowResize,
     uiScene,
     uiCamera,
-    mouseButtonIsDown
+    mouseButtonIsDown,
+    clearSelectedNodes,
 };

--- a/public/main.js
+++ b/public/main.js
@@ -166,6 +166,7 @@ function onDocumentMouseClick(_event) {
       // If the sensor was already selected, we un-highlight it
       clickedNode.material = sensorMaterial;
       selectedSensors.delete(clickedNode.uuid);
+      removeSensorLabel(clickedNode.uuid);
     } else {
       // Else, we highlight it
       clickedNode.material = enlightenedSensorMaterial;


### PR DESCRIPTION
## Feature description

When hovering over a node, the label is displayed and the node and its connections change color. We want to keep this behavior for clicked nodes: i.e., when you click on a node, its label is displayed and its colors change even if you don't keep the cursor over it. We will also need a “reset” button to deselect all clicked nodes.

## Demonstration

![node-highlight](https://github.com/user-attachments/assets/99a8183b-df0d-4377-9a47-6aee498ed3b8)

- Clicking on a node will put it in a "highlighted" state
- When a node is highlighted, the node and its connections change color. Its label is also displayed
- Clicking again on a highlighted node will un-select it
- A button for resetting the node selection is available in the control panel